### PR TITLE
Add property to Enable/Disable The ability for the User to Move the Anchor point

### DIFF
--- a/src/interaction.js
+++ b/src/interaction.js
@@ -107,6 +107,12 @@ export default class RotateFeatureInteraction extends PointerInteraction {
       this.features_ = new Collection()
     }
 
+    /**
+     * @type {boolean}
+     * @public
+     */
+    this.allowAnchorMovement = true || options.allowAnchorMovement;
+
     this.setAnchor(options.anchor || getFeaturesCentroid(this.features_))
     this.setAngle(options.angle || 0)
 
@@ -460,7 +466,7 @@ function handleDownEvent (evt) {
       return true
     }
     // handle click & drag on rotation anchor feature
-    else if (foundFeature && foundFeature === this.anchorFeature_) {
+    else if (foundFeature && foundFeature === this.anchorFeature_ && this.allowAnchorMovement) {
       this.anchorMoving_ = true
       this::handleMoveEvent(evt)
 
@@ -566,7 +572,7 @@ function handleMoveEvent ({ map, pixel }) {
   ) {
     this.previousCursor_ = elem.style.cursor
     setCursor('grab', true)
-  } else if (( foundFeature && foundFeature === this.anchorFeature_ ) || this.anchorMoving_) {
+  } else if (( foundFeature && foundFeature === this.anchorFeature_ && this.allowAnchorMovement) || this.anchorMoving_) {
     this.previousCursor_ = elem.style.cursor
     setCursor('crosshair')
   } else {

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -13,4 +13,5 @@
  *                                      applied for features already added to collection. Default is `0`.
  * @property {number[] | ol.Coordinate | undefined} anchor Initial anchor coordinate. Default is center of features extent.
  * @property {function} condition
+ * @property {boolean | undefined} allowAnchorMovement Allow UI manipulaiton of the Rotation Anchor
  */


### PR DESCRIPTION
Hi,
In my use case, I don't want the user to be able to change the Anchor position by dragging it around. I've added a flag that enables/disables this behavior. By default this property is set to true, so it won't affect any  implementations already in use.