### PR TITLE
Upgrade to ol 8.2 + resolved build 'geoTIFF' issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/runtime": "^7.10.3"
   },
   "peerDependencies": {
-    "ol": "6.x||7.x"
+    "ol": "6.x||7.x||8.x"
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",
@@ -70,7 +70,7 @@
     "lodash": "^4.17.15",
     "mocha": "^8.0.1",
     "mocha-phantomjs": "^4.1.0",
-    "ol": "^7.4.0",
+    "ol": "^8.2.0",
     "phantomjs-prebuilt": "^2.1.16",
     "rollup": "^2.18.1",
     "rollup-plugin-terser": "^6.1.0",

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -12,7 +12,7 @@
 import { Pointer as PointerInteraction } from 'ol/interaction'
 import { Collection, Feature } from 'ol'
 import { Vector as VectorLayer } from 'ol/layer'
-import { Vector as VectorSource } from 'ol/source'
+import VectorSource from 'ol/source/Vector'
 import { GeometryCollection, Point, Polygon } from 'ol/geom'
 import { Fill, RegularShape, Stroke, Style, Text } from 'ol/style'
 import { getCenter as getExtentCenter } from 'ol/extent'

--- a/test/app.js
+++ b/test/app.js
@@ -1,6 +1,7 @@
 import { Feature, Map, View } from 'ol'
 import { Tile as TileLayer, Vector as VectorLayer } from 'ol/layer'
-import { OSM as OSMSource, Vector as VectorSource } from 'ol/source'
+import OSMSource from 'ol/source/OSM'
+import VectorSource from 'ol/source/Vector'
 import { LineString, Point, Polygon } from 'ol/geom'
 import { Select as SelectInteraction } from 'ol/interaction'
 import { Fill, RegularShape, Stroke, Style, Text } from 'ol/style'

--- a/test/unit/specs/interaction.spec.js
+++ b/test/unit/specs/interaction.spec.js
@@ -2,7 +2,7 @@
 import { Collection, Feature, Map, View } from 'ol'
 import { Point } from 'ol/geom'
 import { Vector as VectorLayer } from 'ol/layer'
-import { Vector as VectorSource } from 'ol/source'
+import VectorSource from 'ol/source/Vector'
 import MapBrowserEvent from 'ol/MapBrowserEvent'
 import olEvent from 'ol/events/Event'
 import RotateFeatureInteraction from '../../../src'


### PR DESCRIPTION
Makes a ol-rotate-feature library compatible with openlayers 8.2.0